### PR TITLE
[CVE-2022-29970] Sinatra update

### DIFF
--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
 
   {
     'haml' => '5.0.4',
-    'sinatra-contrib' => '2.0.5'
+    'sinatra-contrib' => '2.2.0'
   }.each do |name, version|
     gem.add_dependency(name, "~> #{version}")
   end


### PR DESCRIPTION
http://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-29970