### PR TITLE
chore | Fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # [Stoplight Admin][1]
 
 [![Gem version][7]][8]
-[![Dependency status][9]][10]
 
 A simple administration interface for [stoplight][2].  Monitor the
 status, failures, and invocations of your stoplights.  Change
@@ -86,13 +85,11 @@ end
 Stoplight is brought to you by [@camdez][4] and [@tfausak][5] from
 [@OrgSync][6].
 
-[1]: https://github.com/orgsync/stoplight-admin
-[2]: https://github.com/orgsync/stoplight
+[1]: https://github.com/bolshakov/stoplight-admin
+[2]: https://github.com/bolshakov/stoplight
 [3]: http://bundler.io
 [4]: https://github.com/camdez
 [5]: https://github.com/tfausak
 [6]: https://github.com/OrgSync
 [7]: https://badge.fury.io/rb/stoplight-admin.svg
 [8]: https://rubygems.org/gems/stoplight-admin
-[9]: https://gemnasium.com/orgsync/stoplight-admin.svg
-[10]: https://gemnasium.com/orgsync/stoplight-admin

--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.version = '0.3.5'
   gem.summary = 'A simple administration interface for Stoplight.'
   gem.description = gem.summary
-  gem.homepage = 'https://github.com/orgsync/stoplight-admin'
+  gem.homepage = 'https://github.com/bolshakov/stoplight-admin'
   gem.license = 'MIT'
 
   {


### PR DESCRIPTION
This is a short PR, which fixes some links in gemspec and the Readme file.
Feel free to add needed information, like contributors' contacts.
Also, I think it would be best if we update a **Website link** in the **About** Section:

<img width="322" alt="Screenshot 2022-12-10 at 13 30 21" src="https://user-images.githubusercontent.com/22339735/206838352-9819cdac-098b-4015-b776-a13617db6781.png">

<img width="649" alt="Screenshot 2022-12-10 at 13 30 48" src="https://user-images.githubusercontent.com/22339735/206838362-0f022307-35dd-4504-a4a7-cf1970feeabe.png">

https://bolshakov.github.io/stoplight-admin/ link should work.