### PR TITLE
Addressing CVE-2022-45442 by bumping sinatra-contrib 2.2.0=>2.2.3

### DIFF
--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
 
   {
     'haml' => '5.0.4',
-    'sinatra-contrib' => '2.2.0'
+    'sinatra-contrib' => '2.2.3'
   }.each do |name, version|
     gem.add_dependency(name, "~> #{version}")
   end


### PR DESCRIPTION
Changelog : https://my.diffend.io/gems/sinatra-contrib/2.2.0/2.2.3

```
Name: sinatra
Version: 2.2.0
CVE: CVE-2022-45442
GHSA: GHSA-2x8x-jmrp-phxw
Criticality: High
URL: https://github.com/sinatra/sinatra/security/advisories/GHSA-2x8x-jmrp-phxw
Description:

  An issue was discovered in Sinatra 2.0 before 2.2.3 and 3.0 before 3.0.4. An
  application is vulnerable to a reflected file download (RFD) attack that sets
  the Content-Disposition header of a response when the filename is derived
  from user-supplied input.

Solution: upgrade to '~> 2.2.3', '>= 3.0.4'
```