### PR TITLE
feat: Minor dependencies update | Fix `URI.escape` bug

### DIFF
--- a/lib/sinatra/stoplight_admin.rb
+++ b/lib/sinatra/stoplight_admin.rb
@@ -103,7 +103,7 @@ module Sinatra
 
       def with_lights
         [*params[:names]]
-          .map  { |l| URI.unescape(l) }
+          .map  { |l| CGI.unescape(l) }
           .each { |l| yield(l) }
       end
     end

--- a/lib/sinatra/views/index.haml
+++ b/lib/sinatra/views/index.haml
@@ -36,31 +36,31 @@
               %td.indicator
                 - if l[:color] == GREEN
                   %form{method: 'post', action: url('/red')}
-                    %input{type: 'hidden', name: 'names', value: URI.escape(l[:name])}
+                    %input{type: 'hidden', name: 'names', value: CGI.escape(l[:name])}
                     %button{type: 'submit', class: 'btn btn-success'}
                       G
                       %span.hidden-xs> REEN
                 - elsif l[:color] == YELLOW
                   %form{method: 'post', action: url('/green')}
-                    %input{type: 'hidden', name: 'names', value: URI.escape(l[:name])}
+                    %input{type: 'hidden', name: 'names', value: CGI.escape(l[:name])}
                     %button{type: 'submit', class: 'btn btn-warning'}
                       Y
                       %span.hidden-xs> ELLOW
                 - else
                   %form{method: 'post', action: url('/green')}
-                    %input{type: 'hidden', name: 'names', value: URI.escape(l[:name])}
+                    %input{type: 'hidden', name: 'names', value: CGI.escape(l[:name])}
                     %button{type: 'submit', class: 'btn btn-danger'}
                       R
                       %span.hidden-xs> ED
               %td.locked
                 - if l[:locked]
                   %form{method: 'post', action: url('/unlock')}
-                    %input{type: 'hidden', name: 'names', value: URI.escape(l[:name])}
+                    %input{type: 'hidden', name: 'names', value: CGI.escape(l[:name])}
                     %button{type: 'submit', class: 'btn btn-link'}
                       %span{class: 'glyphicon glyphicon-lock'}
                 - else
                   %form{method: 'post', action: url('/lock')}
-                    %input{type: 'hidden', name: 'names', value: URI.escape(l[:name])}
+                    %input{type: 'hidden', name: 'names', value: CGI.escape(l[:name])}
                     %button{type: 'submit', class: 'btn btn-link'}
                       %span{class: 'glyphicon glyphicon-minus'}
               %td.name

--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -36,10 +36,10 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'stoplight', '~> 3.0.0'
 
   {
-    'bundler' => '1.10',
-    'pry-byebug' => '3.7.0',
-    'rake' => '11.1',
-    'rspec' => '3.8.0'
+    'bundler' => '2.4',
+    'pry-byebug' => '3.10.0',
+    'rake' => '13.0',
+    'rspec' => '3.12.0'
   }.each do |name, version|
     gem.add_development_dependency(name, "~> #{version}")
   end

--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   end
 
   gem.add_dependency 'redis', '>= 3.2'
-  gem.add_dependency 'stoplight', '>= 1.4'
+  gem.add_dependency 'stoplight', '~> 3.0.0'
 
   {
     'bundler' => '1.10',

--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -27,13 +27,13 @@ Gem::Specification.new do |gem|
 
   {
     'haml' => '5.0',
-    'sinatra-contrib' => '3.0.0'
+    'sinatra-contrib' => '2.2.3'
   }.each do |name, version|
     gem.add_dependency(name, "~> #{version}")
   end
 
   gem.add_dependency 'redis', '>= 3.2'
-  gem.add_dependency 'stoplight', '~> 3.0.0'
+  gem.add_dependency 'stoplight', '>= 1.4'
 
   {
     'bundler' => '2.4',

--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.push(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name = 'stoplight-admin'
-  gem.version = '0.4.0'
+  gem.version = '0.3.6'
   gem.summary = 'A simple administration interface for Stoplight.'
   gem.description = gem.summary
   gem.homepage = 'https://github.com/bolshakov/stoplight-admin'

--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.push(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name = 'stoplight-admin'
-  gem.version = '0.3.5'
+  gem.version = '0.4.0'
   gem.summary = 'A simple administration interface for Stoplight.'
   gem.description = gem.summary
   gem.homepage = 'https://github.com/bolshakov/stoplight-admin'

--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.3'
 
   {
-    'haml' => '5.0.4',
-    'sinatra-contrib' => '2.2.3'
+    'haml' => '5.1.0',
+    'sinatra-contrib' => '3.0.0'
   }.each do |name, version|
     gem.add_dependency(name, "~> #{version}")
   end

--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
     Dir.glob(File.join('lib', '**', '*.rb')) +
     Dir.glob(File.join('lib', '**', '*.haml'))
 
-  gem.required_ruby_version = '>= 1.9.3'
+  gem.required_ruby_version = '>= 2.5.0'
 
   {
     'haml' => '5.1.0',

--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.5.0'
 
   {
-    'haml' => '5.1.0',
+    'haml' => '5.0',
     'sinatra-contrib' => '3.0.0'
   }.each do |name, version|
     gem.add_dependency(name, "~> #{version}")


### PR DESCRIPTION
This ticket aims to minimally update dependencies and fix current issues and prepare an intermediate version before moving to the next milestone.

---

Implements the following functionality:

* Fixes issues with the `URI.escape` method by replacing `URI` usages with `CGI`.
* Sets required ruby version to `>= 2.5.0`.
* ~Sets required `stoplight` version to `~> 3.0.0`.~ - will be bumped in the next PR.
* Bump `haml` version to `~> 5.0`
* ~Bump `sinatra-contrib` version to `~> 3.0.0`~ - will be bumped in the next PR.
* Bump gem version to `0.3.6`.

---

Addresses the following issues:

* https://github.com/bolshakov/stoplight-admin/issues/34