### PR TITLE
Fix injection risk by escaping name

### DIFF
--- a/lib/stoplight_admin/views/index.erb
+++ b/lib/stoplight_admin/views/index.erb
@@ -91,7 +91,7 @@
                 <% end %>
               </td>
               <td class="name">
-                <%= l.name %>
+                <%= ERB::Util.html_escape(l.name) %>
               </td>
               <td class="failures">
                 <% if l.failures %>


### PR DESCRIPTION
If a stoplight with name `<script>alert('injection!')</script>` is created, then it will run on the page.

The injection can be created locally with
`curl -X POST http://127.0.0.1:8080/red?names="inject%3Cscript%3Ealert%28%27injection%27%29%3C%2Fscript%3E"`